### PR TITLE
[dev] `continuous_integration_build`:split->{`library`|`unit_tests`|`run_unit_tests`}

### DIFF
--- a/.github/workflows/continuous_integration_build.yml
+++ b/.github/workflows/continuous_integration_build.yml
@@ -9,5 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: continuous_integration_build_make
-        run: make all
+      - name: continuous_integration_build_make_library
+        run: make library/clic3.o
+      - name: continuous_integration_build_make_unit_tests
+        run: make unit_tests
+      - name: continuous_integration_build_make_run_unit_tests
+        run: make run_unit_tests


### PR DESCRIPTION
- `continuous_integration_build`
- - split:
- - - `library`
- - - `unit_tests`
- - - `run_unit_tests`