### PR TITLE
[enh] `clic3_char_arrays`->{`clic3_char_array_to_float`}.allow_trailing->{`f`};

### DIFF
--- a/sources/clic3_char_arrays.c
+++ b/sources/clic3_char_arrays.c
@@ -160,6 +160,7 @@ unsigned char clic3_char_array_to_float(
   unsigned short int decimal = 0;
 
   unsigned char is_negative = 0;
+  unsigned char has_f = 0;
 
   if (char_current == '-') {
     is_negative = 1;
@@ -177,7 +178,17 @@ unsigned char clic3_char_array_to_float(
       }
 
       decimal = 10;
-    } else if (char_current < '0' || char_current > '9') {
+    } else if (
+      char_current == 'f' &&
+      decimal > 10 &&
+      has_f == 0
+    ) {
+      has_f = 1;
+    } else if (
+      char_current < '0' ||
+      char_current > '9' ||
+      has_f == 1
+    ) {
       return 1;
     } else if (decimal > 0) {
       float_return = (

--- a/unit_tests/sources/unit_tests.clic3_char_arrays.c
+++ b/unit_tests/sources/unit_tests.clic3_char_arrays.c
@@ -67,12 +67,44 @@ unsigned char unit_test_clic3_char_arrays_char_array_to_float_test() {
     &value_float
   );
 
-
-  if (value_float != 3.3f) {
-    return 1;
+  if (
+    value_float != 3.3f ||
+    status_test != 0
+  ) {
+    return 0;
   }
 
-  return status_test == 0;
+  status_test = clic3_char_array_to_float(
+    "123.456f",
+    &value_float
+  );
+
+  if (
+    value_float != 123.456f ||
+    status_test != 0
+  ) {
+    return 0;
+  }
+
+  status_test = clic3_char_array_to_float(
+    "2.13f3",
+    &value_float
+  );
+
+  if (status_test == 0) {
+    return 0;
+  }
+
+  status_test = clic3_char_array_to_float(
+    "invalid_value",
+    &value_float
+  );
+
+  if (status_test == 0) {
+    return 0;
+  }
+
+  return 1;
 }
 
 unsigned char unit_test_clic3_char_arrays_char_array_length_test() {


### PR DESCRIPTION
- `clic3_char_arrays`->{`clic3_char_array_to_float`}.allow_trailing->{`f`};
- - ex_valid: `32.424f`, `97.2489f`, `24893.4f`
- - ex_invalid: `2498.f`, `34982f`, `28439.234f324`, `389.24ff`