### PR TITLE
[bug|dev] `clic3_sort`:safe_guard_against_zero_length_sorts

### DIFF
--- a/sources/clic3_sort.c
+++ b/sources/clic3_sort.c
@@ -5,6 +5,12 @@
     type* to_sort,\
     unsigned long int length_to_sort\
   ) {\
+    if (\
+      length_to_sort == 0\
+    ) {\
+      return;\
+    }\
+    \
     type hold;\
     \
     for (\


### PR DESCRIPTION
- `clic3_sort`:safe_guard_against_zero_length_sorts_causing_an_infinite_loop