### PR TITLE
[dev|enh] `clic3_memory`:modifications

### DIFF
--- a/include/clic3_memory.h
+++ b/include/clic3_memory.h
@@ -10,7 +10,11 @@ void clic3_memory_free(
   void*
 );
 
-void clic3_memory_allocate_raw(
+void* clic3_memory_allocate_raw(
+  unsigned int
+);
+
+void clic3_memory_allocate_unchecked(
   void*,
   unsigned int
 );

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,8 @@ c_standard_library
 - `clic3_memory`:
 - - `clic3_memory_allocate`: allocates memory if the address is `0` or reallocates if the address is not `0`
 - - `clic3_memory_free`: frees memory if the address is not `0`
-- - `clic3_memory_allocate_raw`: always allocates memory
+- - `clic3_memory_allocate_raw`: always returns allocated memory
+- - `clic3_memory_allocate_unchecked`: always allocates memory
 - - `clic3_memory_free_raw`: always frees memory
 - - `clic3_memory_reallocate_raw`: always reallocates memory
 - `clic3_sort`

--- a/sources/clic3_char_arrays.c
+++ b/sources/clic3_char_arrays.c
@@ -445,11 +445,11 @@ char* clic3_char_array_from_unsigned_long_int(
   }
 
   static char* char_array;
-  char_array = 0;
 
-  clic3_memory_allocate(
-    &char_array,
-    255
+  char_array = (
+    clic3_memory_allocate_raw(
+      255
+    )
   );
 
   while (
@@ -512,7 +512,7 @@ char* clic3_char_array_from_unsigned_long_int(
     length_char_array++
   ] = '\0';
 
-  clic3_memory_allocate(
+  clic3_memory_reallocate_raw(
     &char_array, 
     length_char_array
   );
@@ -526,11 +526,11 @@ char* clic3_char_array_from_float(
   unsigned char length_char_array = 1;
 
   static char* char_array;
-  char_array = 0;
-
-  clic3_memory_allocate(
-    &char_array,
-    255
+  
+  char_array = (
+    clic3_memory_allocate_raw(
+      255
+    )
   );
 
   unsigned char negative_is = 0;
@@ -643,7 +643,7 @@ char* clic3_char_array_from_float(
     length_char_array - 1
   ] = '\0';
 
-  clic3_memory_allocate(
+  clic3_memory_reallocate_raw(
     &char_array,
     length_char_array
   );
@@ -689,11 +689,9 @@ char* clic3_char_arrays_concatenate(
   );
 
   static char* char_array_destination;
-  char_array_destination = 0;
 
-  clic3_memory_allocate(
-    &char_array_destination,
-    (
+  char_array_destination = (
+    clic3_memory_allocate_raw(
       length_char_array_destination +
       1
     )
@@ -724,12 +722,10 @@ char** clic3_char_array_split_on_char(
   char deliminator
 ) {
   static char** split_char_arrays;
-  split_char_arrays = 0;
-
-  clic3_memory_allocate(
-    &split_char_arrays,
+  
+  split_char_arrays = clic3_memory_allocate_raw(
     sizeof(
-      char*
+      void*
     )
   );
 
@@ -757,16 +753,16 @@ char** clic3_char_array_split_on_char(
         1
       );
 
-      clic3_memory_allocate(
+      clic3_memory_reallocate_raw(
         &split_char_arrays,
         (
           sizeof(
-            char*
-          ) *
-          (unsigned long int) (
-            split_char_arrays[0]
-          ) +
-          1
+            void*
+          ) * (
+            (unsigned long int)
+            split_char_arrays[0] +
+            1
+          )
         )
       );
 
@@ -785,11 +781,11 @@ char** clic3_char_array_split_on_char(
         )
       );
 
-      clic3_memory_allocate(
-        &split_char_arrays[
-          (unsigned long int) split_char_arrays[0]
-        ],
-        (
+      split_char_arrays[
+        (unsigned long int)
+        split_char_arrays[0]
+      ] = (
+        clic3_memory_allocate_raw(
           length_split_char_array +
           1
         )
@@ -806,7 +802,8 @@ char** clic3_char_array_split_on_char(
       );
 
       split_char_arrays[
-        (unsigned long int) split_char_arrays[0]
+        (unsigned long int)
+        split_char_arrays[0]
       ][
         length_split_char_array
       ] = '\0';
@@ -834,25 +831,27 @@ char** clic3_char_array_split_on_char(
       1
     );
 
-    clic3_memory_allocate(
+    clic3_memory_reallocate_raw(
       &split_char_arrays,
       (
-        (unsigned long int) (
-          split_char_arrays[0]
-        ) +
+        (unsigned long int)
+        split_char_arrays[0] +
         1
       )
     );
 
-    clic3_memory_allocate(
-      &split_char_arrays[
-        (unsigned long int) split_char_arrays[0]
-      ],
-      1
+    split_char_arrays[
+      (unsigned long int)
+      split_char_arrays[0]
+    ] = (
+      clic3_memory_allocate_raw(
+        1
+      )
     );
 
     split_char_arrays[
-      (unsigned long int) split_char_arrays[0]
+      (unsigned long int)
+      split_char_arrays[0]
     ][0] = '\0';
   }
 

--- a/sources/clic3_memory.c
+++ b/sources/clic3_memory.c
@@ -9,7 +9,7 @@ void clic3_memory_allocate(
   if (
     *(void**) address_memory == 0
   ) {
-    clic3_memory_allocate_raw(
+    clic3_memory_allocate_unchecked(
       address_memory,
       length_memory
     );
@@ -33,12 +33,22 @@ void clic3_memory_free(
   }
 }
 
-void clic3_memory_allocate_raw(
+void* clic3_memory_allocate_raw(
+  unsigned int length_memory
+) {
+  return (
+    malloc(
+      length_memory
+    )
+  );
+}
+
+void clic3_memory_allocate_unchecked(
   void* address_memory,
   unsigned int length_memory
 ) {
-  *(void**)address_memory = (
-    malloc(
+  *(void**) address_memory = (
+    clic3_memory_allocate_raw(
       length_memory
     )
   );
@@ -48,9 +58,9 @@ void clic3_memory_reallocate_raw(
   void* address_memory,
   unsigned int length_memory
 ) {
-  *(void**)address_memory = (
+  *(void**) address_memory = (
     realloc(
-      *(void**)address_memory,
+      *(void**) address_memory,
       length_memory
     )
   );

--- a/unit_tests/sources/unit_test_suite.c
+++ b/unit_tests/sources/unit_test_suite.c
@@ -5,11 +5,11 @@
 void unit_test_suite_destroy(
   struct unit_test_suite* unit_test_suite
 ) {
-  clic3_memory_free(
+  clic3_memory_free_raw(
     unit_test_suite->name
   );
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     unit_test_suite->unit_tests
   );
 }

--- a/unit_tests/sources/unit_tests.clic3_bytes.c
+++ b/unit_tests/sources/unit_tests.clic3_bytes.c
@@ -9,17 +9,16 @@
 unsigned char unit_test_clic3_bytes_bytes_copy_test_char() {
   unsigned int length_bytes = 10;
 
-  char* bytes_from = 0;
-  char* bytes_to = 0;
-  
-  clic3_memory_allocate(
-    &bytes_from,
-    length_bytes
+  char* bytes_from = (
+    clic3_memory_allocate_raw(
+      length_bytes
+    )
   );
 
-  clic3_memory_allocate(
-    &bytes_to,
-    length_bytes
+  char* bytes_to = (
+    clic3_memory_allocate_raw(
+      length_bytes
+    )
   );
 
   for (
@@ -60,11 +59,11 @@ unsigned char unit_test_clic3_bytes_bytes_copy_test_char() {
     }
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     bytes_from
   );
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     bytes_to
   );
 
@@ -74,12 +73,8 @@ unsigned char unit_test_clic3_bytes_bytes_copy_test_char() {
 unsigned char unit_test_clic3_bytes_bytes_copy_test_int() {
   unsigned int length_bytes = 10;
 
-  int* bytes_from = 0;
-  int* bytes_to = 0;
-
-  clic3_memory_allocate(
-    &bytes_from,
-    (
+  int* bytes_from = (
+    clic3_memory_allocate_raw(
       sizeof(
         int
       ) *
@@ -87,9 +82,8 @@ unsigned char unit_test_clic3_bytes_bytes_copy_test_int() {
     )
   );
 
-  clic3_memory_allocate(
-    &bytes_to,
-    (
+  int* bytes_to = (
+    clic3_memory_allocate_raw(
       sizeof(
         int
       ) *
@@ -137,11 +131,11 @@ unsigned char unit_test_clic3_bytes_bytes_copy_test_int() {
     }
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     bytes_from
   );
   
-  clic3_memory_free(
+  clic3_memory_free_raw(
     bytes_to
   );
 
@@ -153,13 +147,12 @@ unsigned char unit_test_clic3_bytes_bytes_copy_test_struct() {
     .char_value = 'a',
     .int_value = 104,
     .float_value = 3.12,
-    .pointer = 0
+    .pointer = (
+      clic3_memory_allocate_raw(
+        1
+      )
+    )
   };
-
-  clic3_memory_allocate(
-    &bytes_from.pointer,
-    1
-  );
   
   struct structure_unit_test_clic3_bytes_bytes_copy bytes_to;
 
@@ -182,7 +175,7 @@ unsigned char unit_test_clic3_bytes_bytes_copy_test_struct() {
     copied = 0;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     bytes_from.pointer
   );
 
@@ -205,21 +198,20 @@ struct unit_test unit_test_clic3_bytes_bytes_copy_struct = {
 };
 
 struct unit_test_suite* get_unit_test_suite_clic3_bytes() {
-  struct unit_test_suite* unit_test_suite_clic3_bytes = 0;
-  
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_bytes,
-    sizeof(
-      struct unit_test_suite
+  struct unit_test_suite* unit_test_suite_clic3_bytes = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct unit_test_suite
+      )
     )
   );
 
-  unit_test_suite_clic3_bytes->name = 0;
   unit_test_suite_clic3_bytes->length_name = 12;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_bytes->name,
-    unit_test_suite_clic3_bytes->length_name
+  unit_test_suite_clic3_bytes->name = (
+    clic3_memory_allocate_raw(
+      unit_test_suite_clic3_bytes->length_name
+    )
   );
 
   clic3_bytes_copy(
@@ -228,12 +220,10 @@ struct unit_test_suite* get_unit_test_suite_clic3_bytes() {
     unit_test_suite_clic3_bytes->length_name
   );
 
-  unit_test_suite_clic3_bytes->unit_tests = 0;
   unit_test_suite_clic3_bytes->length_unit_tests = 3;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_bytes->unit_tests,
-    (
+  unit_test_suite_clic3_bytes->unit_tests = (
+    clic3_memory_allocate_raw(
       sizeof(
         struct unit_test*
       ) *

--- a/unit_tests/sources/unit_tests.clic3_char.c
+++ b/unit_tests/sources/unit_tests.clic3_char.c
@@ -119,21 +119,20 @@ struct unit_test unit_test_clic3_char_is_digit = {
 };
 
 struct unit_test_suite* get_unit_test_suite_clic3_char() {
-  struct unit_test_suite* unit_test_suite_clic3_char = 0;
-  
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_char,
-    sizeof(
-      struct unit_test_suite
+  struct unit_test_suite* unit_test_suite_clic3_char = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct unit_test_suite
+      )
     )
   );
 
-  unit_test_suite_clic3_char->name = 0;
   unit_test_suite_clic3_char->length_name = 11;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_char->name,
-    unit_test_suite_clic3_char->length_name
+  unit_test_suite_clic3_char->name = (
+    clic3_memory_allocate_raw(
+      unit_test_suite_clic3_char->length_name
+    )
   );
 
   clic3_bytes_copy(
@@ -142,12 +141,10 @@ struct unit_test_suite* get_unit_test_suite_clic3_char() {
     unit_test_suite_clic3_char->length_name
   );
 
-  unit_test_suite_clic3_char->unit_tests = 0;
   unit_test_suite_clic3_char->length_unit_tests = 4;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_char->unit_tests,
-    (
+  unit_test_suite_clic3_char->unit_tests = (
+    clic3_memory_allocate_raw(
       sizeof(
         struct unit_test*
       ) *

--- a/unit_tests/sources/unit_tests.clic3_char_arrays.c
+++ b/unit_tests/sources/unit_tests.clic3_char_arrays.c
@@ -260,7 +260,7 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     status_test = 0;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     char_array
   );
 
@@ -268,8 +268,10 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     return status_test;
   }
 
-  char_array = clic3_char_array_from_float(
-    -1.9f
+  char_array = (
+    clic3_char_array_from_float(
+      -1.9f
+    )
   );
 
   if (
@@ -282,7 +284,7 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     status_test = 0;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     char_array
   );
 
@@ -290,8 +292,10 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     return status_test;
   }
 
-  char_array = clic3_char_array_from_float(
-    -12.5f
+  char_array = (
+    clic3_char_array_from_float(
+      -12.5f
+    )
   );
 
   if (
@@ -305,7 +309,7 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     status_test = 0;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     char_array
   );
 
@@ -313,8 +317,10 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     return status_test;
   }
 
-  char_array = clic3_char_array_from_float(
-    12.5f
+  char_array = (
+    clic3_char_array_from_float(
+      12.5f
+    )
   );
 
   if (
@@ -327,7 +333,7 @@ unsigned char unit_test_clic3_char_arrays_char_array_from_float_test() {
     status_test = 0;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     char_array
   );
 
@@ -361,7 +367,7 @@ unsigned char unit_test_clic3_char_arrays_char_arrays_concatenate_test() {
     status_test = 0;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     char_array_result
   );
 
@@ -426,12 +432,12 @@ unsigned char unit_test_clic3_char_arrays_char_array_split_on_char_test() {
     i <= (unsigned long int) splits[0];
     ++i
   ) {
-    clic3_memory_free(
+    clic3_memory_free_raw(
       splits[i]
     );
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     splits
   );
 
@@ -509,21 +515,20 @@ struct unit_test unit_test_clic3_char_arrays_char_array_split_on_char = {
 };
 
 struct unit_test_suite* get_unit_test_suite_clic3_char_arrays() {
-  struct unit_test_suite* unit_test_suite_clic3_char_arrays = 0;
-  
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_char_arrays,
-    sizeof(
-      struct unit_test_suite
+  struct unit_test_suite* unit_test_suite_clic3_char_arrays = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct unit_test_suite
+      )
     )
   );
 
-  unit_test_suite_clic3_char_arrays->name = 0;
   unit_test_suite_clic3_char_arrays->length_name = 18;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_char_arrays->name,
-    unit_test_suite_clic3_char_arrays->length_name
+  unit_test_suite_clic3_char_arrays->name = (
+    clic3_memory_allocate_raw(
+      unit_test_suite_clic3_char_arrays->length_name
+    )
   );
 
   clic3_bytes_copy(
@@ -532,13 +537,15 @@ struct unit_test_suite* get_unit_test_suite_clic3_char_arrays() {
     unit_test_suite_clic3_char_arrays->length_name
   );
 
-  unit_test_suite_clic3_char_arrays->unit_tests = 0;
   unit_test_suite_clic3_char_arrays->length_unit_tests = 14;
   
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_char_arrays->unit_tests,
-    sizeof(struct unit_test*) *
-    unit_test_suite_clic3_char_arrays->length_unit_tests
+  unit_test_suite_clic3_char_arrays->unit_tests = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct unit_test*
+      ) *
+      unit_test_suite_clic3_char_arrays->length_unit_tests
+    )
   );
 
   unit_test_suite_clic3_char_arrays->unit_tests[0] = (

--- a/unit_tests/sources/unit_tests.clic3_sort.c
+++ b/unit_tests/sources/unit_tests.clic3_sort.c
@@ -10,11 +10,10 @@
 unsigned char unit_test_clic3_sort_sort_char_test_sort() {
   unsigned long int length_values = 10;
 
-  char* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    length_values
+  char* values = (
+    clic3_memory_allocate_raw(
+      length_values
+    )
   );
 
   values[0] = 'h';
@@ -50,7 +49,7 @@ unsigned char unit_test_clic3_sort_sort_char_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -60,11 +59,10 @@ unsigned char unit_test_clic3_sort_sort_char_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_char_test_sort() {
   unsigned long int length_values = 10;
 
-  char* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    length_values
+  char* values = (
+    clic3_memory_allocate_raw(
+      length_values
+    )
   );
 
   values[0] = 'h';
@@ -100,7 +98,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_char_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -110,11 +108,10 @@ unsigned char unit_test_clic3_sort_sort_reverse_char_test_sort() {
 unsigned char unit_test_clic3_sort_sort_unsigned_char_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned char* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    length_values
+  unsigned char* values = (
+    clic3_memory_allocate_raw(
+      length_values
+    )
   );
 
   values[0] = 'w';
@@ -150,7 +147,7 @@ unsigned char unit_test_clic3_sort_sort_unsigned_char_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -160,11 +157,10 @@ unsigned char unit_test_clic3_sort_sort_unsigned_char_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_unsigned_char_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned char* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    length_values
+  unsigned char* values = (
+    clic3_memory_allocate_raw(
+      length_values
+    )
   );
 
   values[0] = 'i';
@@ -200,7 +196,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_char_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -210,11 +206,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_char_test_sort() {
 unsigned char unit_test_clic3_sort_sort_double_test_sort() {
   unsigned long int length_values = 10;
 
-  double* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  double* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         double
       ) *
@@ -255,7 +248,7 @@ unsigned char unit_test_clic3_sort_sort_double_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -265,11 +258,8 @@ unsigned char unit_test_clic3_sort_sort_double_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_double_test_sort() {
   unsigned long int length_values = 10;
 
-  double* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  double* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         double
       ) *
@@ -310,7 +300,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_double_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -320,11 +310,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_double_test_sort() {
 unsigned char unit_test_clic3_sort_sort_float_test_sort() {
   unsigned long int length_values = 10;
 
-  float* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  float* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         float
       ) *
@@ -365,7 +352,7 @@ unsigned char unit_test_clic3_sort_sort_float_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -375,11 +362,8 @@ unsigned char unit_test_clic3_sort_sort_float_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_float_test_sort() {
   unsigned long int length_values = 10;
 
-  float* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  float* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         float
       ) *
@@ -420,7 +404,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_float_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -430,11 +414,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_float_test_sort() {
 unsigned char unit_test_clic3_sort_sort_int_test_sort() {
   unsigned long int length_values = 10;
 
-  int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         int
       ) *
@@ -475,7 +456,7 @@ unsigned char unit_test_clic3_sort_sort_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -485,11 +466,8 @@ unsigned char unit_test_clic3_sort_sort_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_int_test_sort() {
   unsigned long int length_values = 10;
 
-  int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         int
       ) *
@@ -530,7 +508,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -540,11 +518,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_unsigned_int_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  unsigned int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         unsigned int
       ) *
@@ -585,7 +560,7 @@ unsigned char unit_test_clic3_sort_sort_unsigned_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -595,11 +570,8 @@ unsigned char unit_test_clic3_sort_sort_unsigned_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_unsigned_int_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  unsigned int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         unsigned int
       ) *
@@ -640,7 +612,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -650,11 +622,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_short_int_test_sort() {
   unsigned long int length_values = 10;
 
-  short int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  short int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         short int
       ) *
@@ -695,7 +664,7 @@ unsigned char unit_test_clic3_sort_sort_short_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -705,11 +674,8 @@ unsigned char unit_test_clic3_sort_sort_short_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_short_int_test_sort() {
   unsigned long int length_values = 10;
 
-  short int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  short int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         short int
       ) *
@@ -750,7 +716,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_short_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -760,11 +726,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_short_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_unsigned_short_int_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned short int* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    (
+  unsigned short int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         unsigned short int
       ) *
@@ -805,7 +768,7 @@ unsigned char unit_test_clic3_sort_sort_unsigned_short_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -815,11 +778,8 @@ unsigned char unit_test_clic3_sort_sort_unsigned_short_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_unsigned_short_int_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned short int* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    (
+  unsigned short int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         unsigned short int
       ) *
@@ -860,7 +820,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_short_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -870,11 +830,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_short_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_long_int_test_sort() {
   unsigned long int length_values = 10;
 
-  long int* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    (
+  long int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         long int
       ) *
@@ -915,7 +872,7 @@ unsigned char unit_test_clic3_sort_sort_long_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -925,11 +882,8 @@ unsigned char unit_test_clic3_sort_sort_long_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_long_int_test_sort() {
   unsigned long int length_values = 10;
 
-  long int* values = 0;
-
-  clic3_memory_allocate(
-    &values,
-    (
+  long int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         long int
       ) *
@@ -970,7 +924,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_long_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -980,11 +934,8 @@ unsigned char unit_test_clic3_sort_sort_reverse_long_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_unsigned_long_int_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned long int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  unsigned long int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         unsigned long int
       ) *
@@ -1025,7 +976,7 @@ unsigned char unit_test_clic3_sort_sort_unsigned_long_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -1035,11 +986,8 @@ unsigned char unit_test_clic3_sort_sort_unsigned_long_int_test_sort() {
 unsigned char unit_test_clic3_sort_sort_reverse_unsigned_long_int_test_sort() {
   unsigned long int length_values = 10;
 
-  unsigned long int* values = 0;
-  
-  clic3_memory_allocate(
-    &values,
-    (
+  unsigned long int* values = (
+    clic3_memory_allocate_raw(
       sizeof(
         unsigned long int
       ) *
@@ -1080,7 +1028,7 @@ unsigned char unit_test_clic3_sort_sort_reverse_unsigned_long_int_test_sort() {
     status_test = 1;
   }
 
-  clic3_memory_free(
+  clic3_memory_free_raw(
     values
   );
 
@@ -1188,21 +1136,20 @@ struct unit_test unit_test_clic3_sort_sort_reverse_unsigned_long_int = {
 };
 
 struct unit_test_suite* get_unit_test_suite_clic3_sort() {
-  struct unit_test_suite* unit_test_suite_clic3_sort = 0;
-  
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_sort,
-    sizeof(
-      struct unit_test_suite
+  struct unit_test_suite* unit_test_suite_clic3_sort = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct unit_test_suite
+      )
     )
   );
 
-  unit_test_suite_clic3_sort->name = 0;
   unit_test_suite_clic3_sort->length_name = 11;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_sort->name,
-    unit_test_suite_clic3_sort->length_name
+  unit_test_suite_clic3_sort->name = (
+    clic3_memory_allocate_raw(
+      unit_test_suite_clic3_sort->length_name
+    )
   );
 
   clic3_bytes_copy(
@@ -1211,12 +1158,10 @@ struct unit_test_suite* get_unit_test_suite_clic3_sort() {
     unit_test_suite_clic3_sort->length_name
   );
 
-  unit_test_suite_clic3_sort->unit_tests = 0;
   unit_test_suite_clic3_sort->length_unit_tests = 20;
 
-  clic3_memory_allocate(
-    &unit_test_suite_clic3_sort->unit_tests,
-    (
+  unit_test_suite_clic3_sort->unit_tests = (
+    clic3_memory_allocate_raw(
       sizeof(
         struct unit_test*
       ) *


### PR DESCRIPTION
- `clic3_memory_allocate_raw`: memory allocation as a return value rather than by assigning to the dereferenced pointer reference
- `clic3_memory_allocate_unchecked`:add(functionally_similar_to_previous_iteration_of_raw);
- use `raw` and `unchecked` variations