### PR TITLE
[enh] `clic3_colours`:expand

### DIFF
--- a/include/clic3_colours.h
+++ b/include/clic3_colours.h
@@ -1,29 +1,280 @@
 #ifndef __clic3_colours_h
 #define __clic3_colours_h
 
-#define clic3_colours_definition_foreground "\033[0;30m"
-#define clic3_colours_definition_red "\033[0;31m"
-#define clic3_colours_definition_orange "\033[0;39m"
-#define clic3_colours_definition_yellow "\033[0;33m"
-#define clic3_colours_definition_green "\033[0;32m"
-#define clic3_colours_definition_blue "\033[0;34m"
-#define clic3_colours_definition_cyan "\033[0;36m"
-#define clic3_colours_definition_violet "\033[0;35m"
-#define clic3_colours_definition_indigo clic3_colours_definition_violet
+#define clic3_colours_definition_prefix \033[
+#define clic3_colours_definition_seperator ;
+#define clic3_colours_definition_postfix m
 
-#define clic3_colours_definition_bold_foreground "\033[1;30m"
-#define clic3_colours_definition_bold_red "\033[1;31m"
-#define clic3_colours_definition_bold_orange "\033[1;39m"
-#define clic3_colours_definition_bold_yellow "\033[1;33m"
-#define clic3_colours_definition_bold_green "\033[1;32m"
-#define clic3_colours_definition_bold_blue "\033[1;34m"
-#define clic3_colours_definition_bold_cyan "\033[1;36m"
-#define clic3_colours_definition_bold_violet "\033[1;35m"
-#define clic3_colours_definition_bold_indigo clic3_colours_definition_bold_violet
+#define clic3_colours_definition_char_arrayize_unwrapped(char_array) #char_array
+#define clic3_colours_definition_char_arrayize(char_array) clic3_colours_definition_char_arrayize_unwrapped(char_array)
 
-#define clic3_colours_definition_reset "\033[0;00m"
+#define clic3_colours_definition_prefix_char_array clic3_colours_definition_char_arrayize(clic3_colours_definition_prefix)
+#define clic3_colours_definition_seperator_char_array clic3_colours_definition_char_arrayize(clic3_colours_definition_seperator)
+#define clic3_colours_definition_postfix_char_array clic3_colours_definition_char_arrayize(clic3_colours_definition_postfix)
 
-#define clic3_colours_length_colour 7
+#define clic3_colours_definition_prefix_length 2
+#define clic3_colours_definition_style_length 1
+#define clic3_colours_definition_seperator_length 1
+#define clic3_colours_definition_modifier_length 1
+#define clic3_colours_definition_value_length 1
+#define clic3_colours_definition_postfix_length 1
+
+extern const char clic3_colours_prefix_char_array[
+  clic3_colours_definition_prefix_length
+];
+
+extern const char clic3_colours_seperator_char_array[
+  clic3_colours_definition_seperator_length
+];
+
+extern const char clic3_colours_postfix_char_array[
+  clic3_colours_definition_postfix_length
+];
+
+#define clic3_colours_length_colour (\
+    clic3_colours_definition_prefix_length +\
+    clic3_colours_definition_style_length +\
+    clic3_colours_definition_seperator_length +\
+    clic3_colours_definition_modifier_length +\
+    clic3_colours_definition_value_length +\
+    clic3_colours_definition_postfix_length\
+  )
+
+#define clic3_colours_char_array_unwrapped_double(prefix, style, seperator, modifier, value, postfix)\
+  #prefix\
+  #style\
+  #seperator\
+  #modifier\
+  #value\
+  #postfix
+
+#define clic3_colours_char_array_unwrapped(prefix, style, seperator, modifier, value, postfix)\
+  clic3_colours_char_array_unwrapped_double(\
+    prefix,\
+    style,\
+    seperator,\
+    modifier,\
+    value,\
+    postfix\
+  )
+
+#define clic3_colours_char_array(style, modifier, value)\
+  clic3_colours_char_array_unwrapped(\
+    clic3_colours_definition_prefix,\
+    style,\
+    clic3_colours_definition_seperator,\
+    modifier,\
+    value,\
+    clic3_colours_definition_postfix\
+  )
+
+#define clic3_colours_hex_unwrapped(modifier, value)\
+  0x\
+  ## modifier\
+  ## value
+
+#define clic3_colours_hex(modifier, value)\
+  clic3_colours_hex_unwrapped(\
+    modifier,\
+    value\
+  )
+
+#define clic3_colour_style_definition_basic 0
+#define clic3_colour_style_definition_bold 1
+#define clic3_colour_style_definition_light 2
+#define clic3_colour_style_definition_italic 3
+#define clic3_colour_style_definition_underlined 4
+#define clic3_colour_style_definition_blinking 5
+#define clic3_colour_style_definition_inverse 7
+#define clic3_colour_style_definition_strike_through 9
+
+#define clic3_colour_modifier_definition_reset 0
+#define clic3_colour_modifier_definition_foreground 3
+#define clic3_colour_modifier_definition_background 4
+
+#define clic3_colour_integer_definition_foreground 0
+#define clic3_colour_integer_definition_red 1
+#define clic3_colour_integer_definition_green 2
+#define clic3_colour_integer_definition_yellow 3
+#define clic3_colour_integer_definition_blue 4
+#define clic3_colour_integer_definition_purple 5
+#define clic3_colour_integer_definition_cyan 6
+#define clic3_colour_integer_definition_background 7
+
+enum clic3_colour {
+  clic3_colour_foreground_foreground = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_foreground
+  ),
+  clic3_colour_foreground_red = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_red
+  ),
+  clic3_colour_foreground_green = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_green
+  ),
+  clic3_colour_foreground_yellow = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_yellow
+  ),
+  clic3_colour_foreground_blue = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_blue
+  ),
+  clic3_colour_foreground_purple = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_purple
+  ),
+  clic3_colour_foreground_cyan = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_cyan
+  ),
+  clic3_colour_foreground_background = clic3_colours_hex(
+    clic3_colour_modifier_definition_foreground,
+    clic3_colour_integer_definition_background
+  ),
+  clic3_colour_background_foreground = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_foreground
+  ),
+  clic3_colour_background_red = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_red
+  ),
+  clic3_colour_background_green = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_green
+  ),
+  clic3_colour_background_yellow = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_yellow
+  ),
+  clic3_colour_background_blue = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_blue
+  ),
+  clic3_colour_background_purple = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_purple
+  ),
+  clic3_colour_background_cyan = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_cyan
+  ),
+  clic3_colour_background_background = clic3_colours_hex(
+    clic3_colour_modifier_definition_background,
+    clic3_colour_integer_definition_background
+  )
+};
+
+#define clic3_colours_definition_foreground clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_foreground\
+)
+
+#define clic3_colours_definition_red clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_red\
+)
+
+#define clic3_colours_definition_green clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_green\
+)
+
+#define clic3_colours_definition_yellow clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_yellow\
+)
+
+#define clic3_colours_definition_blue clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_blue\
+)
+
+#define clic3_colours_definition_purple clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_purple\
+)
+
+#define clic3_colours_definition_cyan clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_cyan\
+)
+
+#define clic3_colours_definition_background clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_background\
+)
+
+#define clic3_colours_definition_bold_foreground clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_foreground\
+)
+
+#define clic3_colours_definition_bold_red clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_red\
+)
+
+#define clic3_colours_definition_bold_green clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_green\
+)
+
+#define clic3_colours_definition_bold_yellow clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_yellow\
+)
+
+#define clic3_colours_definition_bold_blue clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_blue\
+)
+
+#define clic3_colours_definition_bold_purple clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_purple\
+)
+
+#define clic3_colours_definition_bold_cyan clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_cyan\
+)
+
+#define clic3_colours_definition_bold_background clic3_colours_char_array(\
+  clic3_colour_style_definition_bold,\
+  clic3_colour_modifier_definition_foreground,\
+  clic3_colour_integer_definition_background\
+)
+
+#define clic3_colours_definition_reset clic3_colours_char_array(\
+  clic3_colour_style_definition_basic,\
+  clic3_colour_modifier_definition_reset,\
+  clic3_colour_integer_definition_foreground\
+)
+
+char* clic3_colours_char_array_construct(
+  unsigned char,
+  unsigned char,
+  unsigned char
+);
 
 extern const char clic3_colours_foreground[
   clic3_colours_length_colour +
@@ -34,31 +285,38 @@ extern const char clic3_colours_red[
   clic3_colours_length_colour +
   1
 ];
+
 extern const char clic3_colours_orange[
   clic3_colours_length_colour +
   1
 ];
+
 extern const char clic3_colours_yellow[
   clic3_colours_length_colour +
   1
 ];
+
 extern const char clic3_colours_green[
   clic3_colours_length_colour +
   1
 ];
+
 extern const char clic3_colours_blue[
   clic3_colours_length_colour +
   1
 ];
+
 extern const char clic3_colours_cyan[
   clic3_colours_length_colour +
   1
 ];
-extern const char clic3_colours_violet[
+
+extern const char clic3_colours_purple[
   clic3_colours_length_colour +
   1
 ];
-extern const char clic3_colours_indigo[
+
+extern const char clic3_colours_background[
   clic3_colours_length_colour +
   1
 ];
@@ -98,12 +356,12 @@ extern const char clic3_colours_bold_cyan[
   1
 ];
 
-extern const char clic3_colours_bold_violet[
+extern const char clic3_colours_bold_purple[
   clic3_colours_length_colour +
   1
 ];
 
-extern const char clic3_colours_colour_bold_indigo[
+extern const char clic3_colours_bold_background[
   clic3_colours_length_colour +
   1
 ];

--- a/sources/clic3_colours.c
+++ b/sources/clic3_colours.c
@@ -1,5 +1,147 @@
 #include <clic3_colours.h>
 
+#include <clic3_memory.h>
+
+const char clic3_colours_prefix_char_array[
+  clic3_colours_definition_prefix_length
+] = (
+  clic3_colours_definition_prefix_char_array
+);
+
+const char clic3_colours_seperator_char_array[
+  clic3_colours_definition_seperator_length
+] = (
+  clic3_colours_definition_seperator_char_array
+);
+
+const char clic3_colours_postfix_char_array[
+  clic3_colours_definition_postfix_length
+] = (
+  clic3_colours_definition_postfix_char_array
+);
+
+char* clic3_colours_char_array_construct(
+  unsigned char clic3_colours_char_array_style,
+  unsigned char clic3_colours_char_array_modifier,
+  unsigned char clic3_colours_char_array_colour
+) {
+  static char* clic3_colour_char_array_constructed;
+
+  clic3_colour_char_array_constructed = (
+    clic3_memory_allocate_raw(
+      clic3_colours_length_colour +
+      1
+    )
+  );
+
+  unsigned char index_clic3_colour_char_array_constructed = (
+    0
+  );
+
+  for (
+    unsigned char index_prefix = 0;
+    index_prefix < clic3_colours_definition_prefix_length;
+    ++index_prefix
+  ) {
+    clic3_colour_char_array_constructed[
+      index_clic3_colour_char_array_constructed
+    ] = (
+      clic3_colours_prefix_char_array[
+        index_prefix
+      ]
+    );
+
+    index_clic3_colour_char_array_constructed = (
+      index_clic3_colour_char_array_constructed +
+      1
+    );
+  }
+
+  clic3_colour_char_array_constructed[
+    index_clic3_colour_char_array_constructed
+  ] = (
+    clic3_colours_char_array_style +
+    '0'
+  );
+
+  index_clic3_colour_char_array_constructed = (
+    index_clic3_colour_char_array_constructed +
+    1
+  );
+
+  for (
+    unsigned char index_seperator = 0;
+    index_seperator < clic3_colours_definition_seperator_length;
+    ++index_seperator
+  ) {
+    clic3_colour_char_array_constructed[
+      index_clic3_colour_char_array_constructed
+    ] = (
+      clic3_colours_seperator_char_array[
+        index_seperator
+      ]
+    );
+
+    index_clic3_colour_char_array_constructed = (
+      index_clic3_colour_char_array_constructed +
+      1
+    );
+  }
+
+  clic3_colour_char_array_constructed[
+    index_clic3_colour_char_array_constructed
+  ] = (
+    clic3_colours_char_array_modifier +
+    '0'
+  );
+
+  index_clic3_colour_char_array_constructed = (
+    index_clic3_colour_char_array_constructed +
+    1
+  );
+
+  clic3_colour_char_array_constructed[
+    index_clic3_colour_char_array_constructed
+  ] = (
+    clic3_colours_char_array_colour +
+    '0'
+  );
+
+  index_clic3_colour_char_array_constructed = (
+    index_clic3_colour_char_array_constructed +
+    1
+  );
+
+  for (
+    unsigned char index_postfix = 0;
+    index_postfix < clic3_colours_definition_postfix_length;
+    ++index_postfix
+  ) {
+    clic3_colour_char_array_constructed[
+      index_clic3_colour_char_array_constructed
+    ] = (
+      clic3_colours_postfix_char_array[
+        index_postfix
+      ]
+    );
+
+    index_clic3_colour_char_array_constructed = (
+      index_clic3_colour_char_array_constructed +
+      1
+    );
+  }
+
+  clic3_colour_char_array_constructed[
+    index_clic3_colour_char_array_constructed
+  ] = (
+    '\0'
+  );
+
+  return (
+    clic3_colour_char_array_constructed
+  );
+}
+
 const char clic3_colours_foreground[
   clic3_colours_length_colour +
   1
@@ -13,14 +155,6 @@ const char clic3_colours_red[
   1
 ] = (
   clic3_colours_definition_red
-  "\0"
-);
-
-const char clic3_colours_orange[
-  clic3_colours_length_colour +
-  1
-] = (
-  clic3_colours_definition_orange
   "\0"
 );
 
@@ -56,19 +190,27 @@ const char clic3_colours_cyan[
   "\0"
 );
 
-const char clic3_colours_violet[
+const char clic3_colours_purple[
   clic3_colours_length_colour +
   1
 ] = (
-  clic3_colours_definition_violet
+  clic3_colours_definition_purple
   "\0"
 );
 
-const char clic3_colours_indigo[
+const char clic3_colours_background[
   clic3_colours_length_colour +
   1
 ] = (
-  clic3_colours_definition_indigo
+  clic3_colours_definition_background
+  "\0"
+);
+
+const char clic3_colours_bold_foreground[
+  clic3_colours_length_colour +
+  1
+] = (
+  clic3_colours_definition_bold_foreground
   "\0"
 );
 
@@ -77,14 +219,6 @@ const char clic3_colours_bold_red[
   1
 ] = (
   clic3_colours_definition_red
-  "\0"
-);
-
-const char clic3_colours_bold_orange[
-  clic3_colours_length_colour +
-  1
-] = (
-  clic3_colours_definition_orange
   "\0"
 );
 
@@ -120,29 +254,22 @@ const char clic3_colours_bold_cyan[
   "\0"
 );
 
-const char clic3_colours_bold_violet[
+const char clic3_colours_bold_purple[
   clic3_colours_length_colour +
   1
 ] = (
-  clic3_colours_definition_violet
+  clic3_colours_definition_purple
   "\0"
 );
 
-const char clic3_colours_colour_bold_indigo[
+const char clic3_colours_bold_background[
   clic3_colours_length_colour +
   1
 ] = (
-  clic3_colours_definition_bold_indigo
+  clic3_colours_definition_bold_background
   "\0"
 );
 
-const char clic3_colours_bold_foreground[
-  clic3_colours_length_colour +
-  1
-] = (
-  clic3_colours_definition_bold_foreground
-  "\0"
-);
 
 const char clic3_colours_reset[
   clic3_colours_length_colour +


### PR DESCRIPTION
- `clic3_colours`:expand
- - remove indigo and violet, they're just called purple now
- - remove orange it doesnt exist not a colour bye orange
- - add in background colour
- - add in macros
- - add constructor function
- - add an enum in
- - add style defines
- - add modifier defines

grape soda sucks, drink orange fanta

  CAN YOU FEEL THE SUNSHINE


https://github.com/user-attachments/assets/c91a52fa-7168-4d34-9e05-c5807610d599

